### PR TITLE
Use 'system.file' so that path can be determined also when package is no...

### DIFF
--- a/R/WriteXLS.R
+++ b/R/WriteXLS.R
@@ -128,7 +128,7 @@ WriteXLS <- function(x, ExcelFileName = "R.xls", SheetNames = NULL, perl = "perl
   }
   
   # Get path to WriteXLS.pl or WriteXLSX.pl
-  Perl.Path <- file.path(path.package("WriteXLS"), "Perl")
+  Perl.Path <- system.file("Perl", package = "WriteXLS")
 
   PerlScript <- ifelse(XLSX, "WriteXLSX.pl", "WriteXLS.pl")
   


### PR DESCRIPTION
I wanted to use the function 'WriteXLS' without loading the package, i.e., via 'WriteXLS::WriteXLS'. This failed because 'path.package' fails when the package is not loaded.
