### PR TITLE
fix crash in testPerl(verbose = FALSE) if perl is not found

### DIFF
--- a/R/testPerl.R
+++ b/R/testPerl.R
@@ -18,9 +18,10 @@ testPerl <- function(perl = "perl", verbose = TRUE) {
   ## Check For Perl first
   res <- Sys.which(perl)
   
-  if ((res == "") & (verbose)) {
-    message("\nPerl was not found on your system. Either check $PATH if installed or please install Perl.\n",
-            paste("For more information see: ", system.file('INSTALL', package='WriteXLS')), "\n")
+  if (res == "") {
+    if (verbose)
+      message("\nPerl was not found on your system. Either check $PATH if installed or please install Perl.\n",
+              paste("For more information see: ", system.file('INSTALL', package='WriteXLS')), "\n")
     
     invisible(FALSE)
   } else {


### PR DESCRIPTION
If `perl` is not found on a system, `testPerl(verbose = FALSE)` fails:

```
> testPerl(verbose = FALSE)
sh: 1: perl: not found
Error in system(CMD, intern = TRUE) : error in running command
```

This is due to the fact that the first if clause evaluates to false even when `perl` was not found. The else block then tries to run `perl` which of course fails.